### PR TITLE
Support ExportNamedDeclaration and ExportAllDeclaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 module.exports = function () {
     return {
         visitor: {
+            ExportDeclaration(path) {
+                if (path.node.source) {
+                    path.node.source.value = path.node.source.value.split(/\/jsnext$/)[0]
+                }
+            },
             ImportDeclaration(path) {
                 path.node.source.value = path.node.source.value.split(/\/jsnext$/)[0]
             }

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,22 @@ it('transforms "../foo/bar/jsnext to foo-bar"', function () {
     assert(actual === expected)
 })
 
+it('transforms named export', function () {
+    const code = 'export { abc as xyz } from "../foo/bar/jsnext";'
+    const expected = 'export { abc as xyz } from "../foo/bar";'
+
+    const actual = babel.transform(code, { plugins: [pluginPath] }).code
+    assert(actual === expected)
+})
+
+it('transforms export all', function () {
+    const code = 'export * from "../foo/bar/jsnext";'
+    const expected = 'export * from "../foo/bar";'
+
+    const actual = babel.transform(code, { plugins: [pluginPath] }).code
+    assert(actual === expected)
+})
+
 it('does not transform "foo-bar/jsnext.js to foo-bar"', function () {
     const code = 'import abc from "foo-bar/jsnext.js";'
     const expected = 'import abc from "foo-bar/jsnext.js";'


### PR DESCRIPTION
`babel-plugin-transform-strip-jsnext` cannot transform named export and export all.

## failed test cases
```js
it('transforms named export', function () {
    const code = 'export { abc as xyz } from "../foo/bar/jsnext";'
    const expected = 'export { abc as xyz } from "../foo/bar";'

    const actual = babel.transform(code, { plugins: [pluginPath] }).code
    assert(actual === expected)
})

it('transforms export all', function () {
    const code = 'export * from "../foo/bar/jsnext";'
    const expected = 'export * from "../foo/bar";'

    const actual = babel.transform(code, { plugins: [pluginPath] }).code
    assert(actual === expected)
})
```

I fixed this problem.
Please review my PR.